### PR TITLE
feat: Add option to disable converting null and undefined to None

### DIFF
--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -263,8 +263,23 @@ describe("Option", () => {
     expect(doubleNested1.strictEquals(doubleNested2)).toEqual(true);
   });
 
-  it("converts null and undefined to None", () => {
+  it("converts null and undefined to None by default", () => {
     const opt = Some<number>(null);
     expect(opt.isNone()).toBe(true);
+
+    const opt2 = Some<number>(undefined);
+    expect(opt2.isNone()).toBe(true);
+
+    const opt3 = Some<number>(null, false);
+    expect(opt3.isNone()).toBe(false);
+
+    const opt4 = Some<number>(undefined, false);
+    expect(opt4.isNone()).toBe(false);
+
+    const opt5 = opt3.map((x) => x);
+    expect(opt5.isNone()).toBe(true);
+
+    const opt6 = opt3.map((x) => x, false);
+    expect(opt6.isNone()).toBe(false);
   });
 });


### PR DESCRIPTION
This PR adds an optional argument to `Some()` and the `map...()` family of methods to disable automatically coercing `null` and `undefined` values to `None`.

```typescript
const opt = Some(null, false);
expect(opt.isSome()).toBe(true);

const opt2 = opt.map(value => value)
expect(opt2.isSome()).toBe(false);

const opt3 = opt.map(value => value, false)
expect(opt3.isSome()).toBe(true);
```